### PR TITLE
clean up and gas optimizations

### DIFF
--- a/src/MirakaiScrollsRenderer.sol
+++ b/src/MirakaiScrollsRenderer.sol
@@ -95,14 +95,14 @@ contract MirakaiScrollsRenderer is Ownable {
                     "data:application/json;base64,",
                     Base64.encode(
                         abi.encodePacked(
-                            '{"'
+                            '{'
                                 '"name": "Scroll ', toString(tokenId), '",'
                                 '"description": "description x",'
                                 '"image": "data:image/svg+xml;base64,',
                                     render(tokenId, dna),'",'
                                 '"attributes":',
                                     formatTraits(traitIndexes),
-                            "}"
+                            '}'
                         )
                     )
                 )

--- a/src/MirakaiScrollsRenderer.sol
+++ b/src/MirakaiScrollsRenderer.sol
@@ -26,6 +26,9 @@ import "./interfaces/IMirakaiDnaParser.sol";
 // import {console} from "forge-std/console.sol";
 
 contract MirakaiScrollsRenderer is Ownable {
+
+    uint256 private constant SCROLL_WIDTH = 24;
+
     address public mirakaDnaParser;
 
     // storing scroll font in contract storage using sstore2 because
@@ -34,8 +37,32 @@ contract MirakaiScrollsRenderer is Ownable {
     mapping(uint256 => address) public font;
 
     // scroll pixel coordinates on a 24x24 grid
+    // each digit represents a CSS color class index: c0, c1, c2, c3, c4
     string private pixelScroll =
-        "000111111111111111110000001222222222222222221000001233333333333333321000000111111111111111110000000433333333333333340000000422222222222222340000000422222222222222340000000122222222222222340000000422222222222222340000000122222222222222340000000122222222222222340000000012222222222222340000000122222222222222340000000122222222222222310000000422222222222222340000000122222222222222310000000422222222222222100000000422222222222222310000000422222222222222310000000422222222222223340000000111111111111111110000001222222222222222221000001233333333333333321000000111111111111111110000";
+        "000111111111111111110000"
+        "001222222222222222221000"
+        "001233333333333333321000"
+        "000111111111111111110000"
+        "000433333333333333340000"
+        "000422222222222222340000"
+        "000422222222222222340000"
+        "000122222222222222340000"
+        "000422222222222222340000"
+        "000122222222222222340000"
+        "000122222222222222340000"
+        "000012222222222222340000"
+        "000122222222222222340000"
+        "000122222222222222310000"
+        "000422222222222222340000"
+        "000122222222222222310000"
+        "000422222222222222100000"
+        "000422222222222222310000"
+        "000422222222222222310000"
+        "000422222222222223340000"
+        "000111111111111111110000"
+        "001222222222222222221000"
+        "001233333333333333321000"
+        "000111111111111111110000";
 
     struct Cursor {
         uint8 x;
@@ -47,10 +74,6 @@ contract MirakaiScrollsRenderer is Ownable {
     }
 
     uint256 public constant NUM_TRAITS = 10;
-
-    uint256[][NUM_TRAITS] public WEIGHTS;
-    string[][NUM_TRAITS] public TRAITS;
-    string[NUM_TRAITS] public categories;
 
     constructor() {}
 
@@ -71,16 +94,15 @@ contract MirakaiScrollsRenderer is Ownable {
                 abi.encodePacked(
                     "data:application/json;base64,",
                     Base64.encode(
-                        bytes(
-                            abi.encodePacked(
-                                '{"name": "Scroll',
-                                toString(tokenId),
-                                '", "description": "description x", "image": "data:image/svg+xml;base64,',
-                                render(tokenId, dna),
-                                '", "attributes":',
-                                formatTraits(traitIndexes),
-                                "}"
-                            )
+                        abi.encodePacked(
+                            '{"'
+                                '"name": "Scroll ', toString(tokenId), '",'
+                                '"description": "description x",'
+                                '"image": "data:image/svg+xml;base64,',
+                                    render(tokenId, dna),'",'
+                                '"attributes":',
+                                    formatTraits(traitIndexes),
+                            "}"
                         )
                     )
                 )
@@ -107,7 +129,7 @@ contract MirakaiScrollsRenderer is Ownable {
     ==             On-chain Rendering Functions. Pain             ==
     ==============================================================*/
 
-    function pixelFour(string[24] memory lookup, Cursor memory cursor)
+    function pixelFour(string[SCROLL_WIDTH] memory lookup, Cursor memory cursor)
         internal
         pure
         returns (string memory)
@@ -115,36 +137,32 @@ contract MirakaiScrollsRenderer is Ownable {
         return
             string(
                 abi.encodePacked(
-                    "<rect class='c",
-                    cursor.colorOne,
-                    "' x='",
-                    lookup[cursor.x],
-                    "' y='",
-                    lookup[cursor.y],
-                    "' width='1' height='1' />",
-                    "<rect class='c",
-                    cursor.colorTwo,
-                    "' x='",
-                    lookup[cursor.x + 1],
-                    "' y='",
-                    lookup[cursor.y],
-                    "' width='1' height='1' />",
+                    "<rect "
+                        "class='c", cursor.colorOne,
+                        "' x='", lookup[cursor.x],
+                        "' y='", lookup[cursor.y],
+                        "' width='1' height='1' "
+                    "/>"
+                    "<rect "
+                        "class='c", cursor.colorTwo,
+                        "' x='", lookup[cursor.x + 1],
+                        "' y='", lookup[cursor.y],
+                        "' width='1' height='1' "
+                    "/>",
                     string(
                         abi.encodePacked(
-                            "<rect class='c",
-                            cursor.colorThree,
-                            "' x='",
-                            lookup[cursor.x + 2],
-                            "' y='",
-                            lookup[cursor.y],
-                            "' width='1' height='1' />",
-                            "<rect class='c",
-                            cursor.colorFour,
-                            "' x='",
-                            lookup[cursor.x + 3],
-                            "' y='",
-                            lookup[cursor.y],
-                            "' width='1' height='1' />"
+                            "<rect "
+                                "class='c", cursor.colorThree,
+                                "' x='", lookup[cursor.x + 2],
+                                "' y='", lookup[cursor.y],
+                                "' width='1' height='1' "
+                            "/>"
+                            "<rect "
+                                "class='c", cursor.colorFour,
+                                "' x='", lookup[cursor.x + 3],
+                                "' y='", lookup[cursor.y],
+                                "' width='1' height='1' "
+                            "/>"
                         )
                     )
                 )
@@ -152,30 +170,13 @@ contract MirakaiScrollsRenderer is Ownable {
     }
 
     function setCursorColors(
-        Cursor memory cursor,
-        uint16 i,
-        uint16 offset
+        Cursor memory cursor
     ) internal view {
-        cursor.colorOne = substring(
-            pixelScroll,
-            4 * i + offset,
-            (4 * i) + 1 + offset
-        );
-        cursor.colorTwo = substring(
-            pixelScroll,
-            4 * i + 1 + offset,
-            (4 * i) + 2 + offset
-        );
-        cursor.colorThree = substring(
-            pixelScroll,
-            4 * i + 2 + offset,
-            (4 * i) + 3 + offset
-        );
-        cursor.colorFour = substring(
-            pixelScroll,
-            4 * i + 3 + offset,
-            (4 * i) + 4 + offset
-        );
+        uint256 _offset = SCROLL_WIDTH * cursor.y + cursor.x;
+        cursor.colorOne = string(abi.encodePacked((bytes(pixelScroll)[_offset])));
+        cursor.colorTwo = string(abi.encodePacked((bytes(pixelScroll)[_offset + 1])));
+        cursor.colorThree = string(abi.encodePacked((bytes(pixelScroll)[_offset + 2])));
+        cursor.colorFour = string(abi.encodePacked((bytes(pixelScroll)[_offset + 3])));
     }
 
     /**
@@ -191,19 +192,26 @@ contract MirakaiScrollsRenderer is Ownable {
             mirakaDnaParser
         ).getTraitNames(traitIndexes);
 
-        for (uint256 i = 0; i < traitIndexes.length; i++) {
+        uint256 traitIndexesLength = traitIndexes.length;
+        uint256 i;
+        for (; i < traitIndexesLength;) {
             attributes = string(
                 abi.encodePacked(
                     attributes,
-                    '{"trait_type":"',
-                    IMirakaiDnaParser(mirakaDnaParser).categories(i),
-                    '","value":"',
-                    traitNames[i],
+                    '{'
+                        '"trait_type":"',
+                            IMirakaiDnaParser(mirakaDnaParser).getCategory(uint8(i)), '",'
+                        '"value":"',
+                            traitNames[i],
                     '"}'
                 )
             );
 
-            if (i != 9) attributes = string(abi.encodePacked(attributes, ","));
+            if (i != (NUM_TRAITS - 1)) attributes = string(abi.encodePacked(attributes, ","));
+
+            unchecked {
+                ++i;
+            }
         }
 
         return string(abi.encodePacked("[", attributes, "]"));
@@ -212,7 +220,7 @@ contract MirakaiScrollsRenderer is Ownable {
     /**
      * @dev construct scroll svg - all scrolls are essentially the same shape and bg
      */
-    function drawScroll(string[24] memory lookup)
+    function drawScroll(string[SCROLL_WIDTH] memory lookup)
         internal
         view
         returns (string memory)
@@ -223,38 +231,21 @@ contract MirakaiScrollsRenderer is Ownable {
         Cursor memory cursor;
         cursor.y = 0;
 
-        for (uint16 i = 0; i < 144; i += 6) {
+        for (; cursor.y < SCROLL_WIDTH;) {
             cursor.x = 0;
 
-            // 0-3
-            setCursorColors(cursor, i, 0);
-            p[0] = pixelFour(lookup, cursor); // 0 - 3
-            cursor.x += 4;
+            uint256 i;
+            for(; i < 6;) {
+                setCursorColors(cursor);
+                p[i] = pixelFour(lookup, cursor);
+                cursor.x += 4;
 
-            // 4-7
-            setCursorColors(cursor, i, 4);
-            p[1] = pixelFour(lookup, cursor); // 4 - 7
-            cursor.x += 4;
+                unchecked {
+                    ++i;
+                }
+            }
 
-            // 8-11
-            setCursorColors(cursor, i, 8);
-            p[2] = pixelFour(lookup, cursor); // 8 - 11
-            cursor.x += 4;
-
-            // 12-15
-            setCursorColors(cursor, i, 12);
-            p[3] = pixelFour(lookup, cursor); // 12 - 15
-            cursor.x += 4;
-
-            // 16-19
-            setCursorColors(cursor, i, 16);
-            p[4] = pixelFour(lookup, cursor); // 16 - 19
-            cursor.x += 4;
-
-            // 20-23
-            setCursorColors(cursor, i, 20);
-            p[5] = pixelFour(lookup, cursor); // 20 - 23
-
+            // Appending a row of pixels
             svgScrollString = string(
                 abi.encodePacked(
                     svgScrollString,
@@ -267,7 +258,10 @@ contract MirakaiScrollsRenderer is Ownable {
                 )
             );
 
-            cursor.y++;
+            unchecked {
+                ++cursor.y;
+            }
+            
         }
         return svgScrollString;
     }
@@ -275,7 +269,7 @@ contract MirakaiScrollsRenderer is Ownable {
     /**
      * @dev draw the actual traits onto the scroll
      */
-    function drawItems(string[24] memory lookup, uint256 dna)
+    function drawItems(string[SCROLL_WIDTH] memory lookup, uint256 dna)
         internal
         view
         returns (string memory, uint256)
@@ -296,7 +290,8 @@ contract MirakaiScrollsRenderer is Ownable {
         ).getTraitWeights(traitIndexes);
 
         string memory svgItemsScroll;
-        for (uint8 i = 0; i < NUM_TRAITS; i++) {
+        uint8 i;
+        for (;i < NUM_TRAITS;) {
             // clear tag
             extraTag = "";
 
@@ -309,17 +304,21 @@ contract MirakaiScrollsRenderer is Ownable {
             svgItemsScroll = string(
                 abi.encodePacked(
                     svgItemsScroll,
-                    "<text font-family='Silkscreen' class='t",
-                    lookup[i],
-                    "' ",
-                    extraTag,
-                    " x='5.5' y='",
-                    lookup[7 + ((i % 5) * 2)],
+                    "<text "
+                        "font-family='Silkscreen' "
+                        "class='t", lookup[i], "' ",
+                        extraTag,
+                        " x='5.5' y='",
+                            lookup[7 + ((i % 5) * 2)],
                     "'>",
-                    traitNames[i],
+                        traitNames[i],
                     "</text>"
                 )
             );
+
+            unchecked {
+                ++i;
+            }
         }
         return (svgItemsScroll, numRareTraits);
     }
@@ -333,7 +332,7 @@ contract MirakaiScrollsRenderer is Ownable {
         returns (string memory)
     {
         // 0. Init
-        string[24] memory lookup = [
+        string[SCROLL_WIDTH] memory lookup = [
             "0",
             "1",
             "2",
@@ -360,8 +359,9 @@ contract MirakaiScrollsRenderer is Ownable {
             "23"
         ];
 
-        string
-            memory svgString = "<rect height='100%' width='100%' fill='#050A24' /><g class='floating'>";
+        string memory svgString = 
+            "<rect height='100%' width='100%' fill='#050A24' />"
+            "<g class='floating'>";
 
         // 1. Draw the scroll.
         svgString = string(abi.encodePacked(svgString, drawScroll(lookup)));
@@ -379,8 +379,8 @@ contract MirakaiScrollsRenderer is Ownable {
         svgString = string(
             abi.encodePacked(
                 svgString,
-                "<text x='50%' y='33' dominant-baseline='middle' text-anchor='middle' class='title'>SCROLL #",
-                toString(tokenId),
+                "<text x='50%' y='33' dominant-baseline='middle' text-anchor='middle' class='title'>"
+                    "SCROLL #", toString(tokenId),
                 "</text>"
             )
         );
@@ -388,24 +388,122 @@ contract MirakaiScrollsRenderer is Ownable {
         // extra style to for differing scroll glows depending on # rare items
         string memory extraStyle;
 
-        if (rareItems >= 2) {
-            extraStyle = "<style>@keyframes floating{from{transform: translate(6.5px,3.5px); filter: drop-shadow(0px 0px 1.25px rgba(120, 120, 180, .85));}50%{transform: translate(6.5px,5px); filter: drop-shadow(0px 0px 2.5px rgba(120, 120, 190, 1));}to{transform: translate(6.5px,3.5px); filter: drop-shadow(0px 0px 1.25px rgba(120, 120, 180,.85));}}</style>";
+        if (rareItems > 1) {
+            extraStyle = 
+                    "@keyframes floating{"
+                        "from{"
+                            "transform: translate(6.5px,3.5px);"
+                            "filter: drop-shadow(0px 0px 1.25px rgba(120, 120, 180, .85));"
+                        "}"
+                        "50%{"
+                            "transform: translate(6.5px,5px);"
+                            "filter: drop-shadow(0px 0px 2.5px rgba(120, 120, 190, 1));"
+                        "}"
+                        "to{"
+                            "transform: translate(6.5px,3.5px);"
+                            "filter: drop-shadow(0px 0px 1.25px rgba(120, 120, 180,.85));"
+                        "}"
+                    "}";
         }
 
-        if (rareItems >= 3) {
-            extraStyle = "<style>@keyframes floating{from{transform: translate(6.5px,3.5px); filter: drop-shadow(0px 0px 1.75px rgba(135,232,252,0.8));}50%{transform: translate(6.5px,5px); filter: drop-shadow(0px 0px 3.5px rgba(135,232,252,1));}to{transform: translate(6.5px,3.5px); filter: drop-shadow(0px 0px 1.75px rgba(135,232,252,0.8));}}</style>";
+        if (rareItems > 2) {
+            extraStyle = 
+                    "@keyframes floating{"
+                        "from{"
+                            "transform: translate(6.5px,3.5px);"
+                            "filter: drop-shadow(0px 0px 1.75px rgba(135,232,252,0.8));"
+                        "}"
+                        "50%{"
+                            "transform: translate(6.5px,5px);"
+                            "filter: drop-shadow(0px 0px 3.5px rgba(135,232,252,1));"
+                        "}"
+                        "to{"
+                            "transform: translate(6.5px,3.5px);"
+                            "filter: drop-shadow(0px 0px 1.75px rgba(135,232,252,0.8));"
+                        "}"
+                    "}";
         }
 
         // 4. Close the SVG.
         svgString = string(
             abi.encodePacked(
-                "<svg version='1.1' width='550' height='550' viewBox='0 0 36 36' xmlns='http://www.w3.org/2000/svg' shape-rendering='crispEdges'>",
-                svgString,
-                "<style>@font-face{font-family:Silkscreen;font-style:normal;src:url(",
-                // read the font from contract storage
-                string(SSTORE2.read(font[0])),
-                ") format('truetype')}.title{font-family:Silkscreen;font-size:2px;fill:white}.floating{animation:floating 4s ease-in-out infinite alternate}@keyframes floating{from{transform:translate(6.5px,3.5px);filter:drop-shadow(0px 0px 1.25px rgba(239, 91, 91, .65))}50%{transform:translate(6.5px,5px);filter:drop-shadow(0px 0px 2.5px rgba(239, 91, 91, 1))}to{transform:translate(6.5px,3.5px);filter:drop-shadow(0px 0px 1.25px rgba(239, 91, 91, .65))}}.t0,.t1,.t2,.t3,.t4,.t5,.t6,.t7,.t8,.t9{font-family:Silkscreen;font-size:1.15px;color:#000;animation:textOneAnim 10.5s ease-in-out infinite forwards;opacity:0;animation-delay:.25s}.t5,.t6,.t7,.t8,.t9{animation-name:textTwoAnim}.t1{animation-delay:1.5s}.t2{animation-delay:2.5s}.t3{animation-delay:3.5s}.t4{animation-delay:4.5s}.t5{animation-delay:5.5s}.t6{animation-delay:6.5s}.t7{animation-delay:7.5s}.t8{animation-delay:8.5s}.t9{animation-delay:9.5s}@keyframes textOneAnim{from{opacity:0}10%{opacity:1}42.5%{opacity:1}50%{opacity:0}to{opacity:0}}@keyframes textTwoAnim{from{opacity:0}22.5%{opacity:1}30%{opacity:1}40%{opacity:1}50%{opacity:0}to{opacity:0}}.c0{fill:transparent}.c1{fill:#8b3615}.c2{fill:#d49443}.c3{fill:#c57032}.c4{fill:#76290c}</style>",
-                extraStyle,
+                "<svg version='1.1' width='550' height='550' viewBox='0 0 36 36' "
+                    "xmlns='http://www.w3.org/2000/svg' shape-rendering='crispEdges'"
+                ">",
+                    svgString,
+                    "<style>"
+                        "@font-face{"
+                            "font-family:Silkscreen;"
+                            "font-style:normal;"
+                            "src:url(",
+                                // read the font from contract storage
+                                string(SSTORE2.read(font[0])),
+                            ") format('truetype')"
+                        "}"
+                        ".title{"
+                            "font-family:Silkscreen;"
+                            "font-size:2px;"
+                            "fill:#fff"
+                        "}"
+                        ".floating{"
+                            "animation:floating 4s ease-in-out infinite alternate"
+                        "}"
+                        "@keyframes floating{"
+                            "from{"
+                                "transform:translate(6.5px,3.5px);"
+                                "filter:drop-shadow(0px 0px 1.25px rgba(239, 91, 91, .65))"
+                            "}"
+                            "50%{"
+                                "transform:translate(6.5px,5px);"
+                                "filter:drop-shadow(0px 0px 2.5px rgba(239, 91, 91, 1))"
+                            "}"
+                            "to{"
+                                "transform:translate(6.5px,3.5px);"
+                                "filter:drop-shadow(0px 0px 1.25px rgba(239, 91, 91, .65))"
+                            "}"
+                        "}"
+                        ".t0,.t1,.t2,.t3,.t4,.t5,.t6,.t7,.t8,.t9{"
+                            "font-family:Silkscreen;"
+                            "font-size:1.15px;"
+                            "color:#000;"
+                            "animation:textOneAnim 10.5s ease-in-out infinite forwards;"
+                            "opacity:0;"
+                            "animation-delay:.25s"
+                        "}"
+                        ".t5,.t6,.t7,.t8,.t9{"
+                            "animation-name:textTwoAnim"
+                        "}"
+                        ".t1{animation-delay:1.5s}"
+                        ".t2{animation-delay:2.5s}"
+                        ".t3{animation-delay:3.5s}"
+                        ".t4{animation-delay:4.5s}"
+                        ".t5{animation-delay:5.5s}"
+                        ".t6{animation-delay:6.5s}"
+                        ".t7{animation-delay:7.5s}"
+                        ".t8{animation-delay:8.5s}"
+                        ".t9{animation-delay:9.5s}"
+                        "@keyframes textOneAnim{"
+                            "from{opacity:0}"
+                            "10%{opacity:1}"
+                            "42.5%{opacity:1}"
+                            "50%{opacity:0}"
+                            "to{opacity:0}"
+                        "}"
+                        "@keyframes textTwoAnim{"
+                            "from{opacity:0}"
+                            "22.5%{opacity:1}"
+                            "30%{opacity:1}"
+                            "40%{opacity:1}"
+                            "50%{opacity:0}"
+                            "to{opacity:0}"
+                        "}"
+                        ".c0{fill:transparent}"
+                        ".c1{fill:#8b3615}"
+                        ".c2{fill:#d49443}"
+                        ".c3{fill:#c57032}"
+                        ".c4{fill:#76290c}",
+                        extraStyle,
+                    "</style>",
                 "</svg>"
             )
         );
@@ -416,19 +514,6 @@ contract MirakaiScrollsRenderer is Ownable {
     /*==============================================================
     ==              Utils - copied from other libs                ==
     ==============================================================*/
-
-    function substring(
-        string memory str,
-        uint256 startIndex,
-        uint256 endIndex
-    ) internal pure returns (string memory) {
-        bytes memory strBytes = bytes(str);
-        bytes memory result = new bytes(endIndex - startIndex);
-        for (uint256 i = startIndex; i < endIndex; i++) {
-            result[i - startIndex] = strBytes[i];
-        }
-        return string(result);
-    }
 
     function toString(uint256 value) internal pure returns (string memory) {
         if (value == 0) {

--- a/src/interfaces/IMirakaiDnaParser.sol
+++ b/src/interfaces/IMirakaiDnaParser.sol
@@ -26,5 +26,5 @@ interface IMirakaiDnaParser {
 
     function cc0Traits(uint256 scrollDna) external pure returns (uint256);
 
-    function categories(uint256 index) external view returns (string memory);
+    function getCategory(uint8 index) external pure returns (string memory);
 }

--- a/test/MirakaiHeroes.t.sol
+++ b/test/MirakaiHeroes.t.sol
@@ -66,7 +66,7 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         // flip all flags
         mirakaiScrolls.flipCC0Mint();
         mirakaiScrolls.flipMint();
-        mirakaiScrolls.setCc0TraitsProbability(100);
+        mirakaiScrolls.setCc0TraitsProbability(10000);
 
         mirakaiHeroes.setSummonCost(50e18); // 50 $ORBS
 
@@ -118,7 +118,7 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         // flip all flags
         mirakaiScrolls.flipCC0Mint();
         mirakaiScrolls.flipMint();
-        mirakaiScrolls.setCc0TraitsProbability(100);
+        mirakaiScrolls.setCc0TraitsProbability(10000);
 
         mirakaiHeroes.setSummonCost(50e18); // 50 $ORBS
 
@@ -177,7 +177,7 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         // flip all flags
         mirakaiScrolls.flipCC0Mint();
         mirakaiScrolls.flipMint();
-        mirakaiScrolls.setCc0TraitsProbability(100);
+        mirakaiScrolls.setCc0TraitsProbability(10000);
 
         mirakaiHeroes.setSummonCost(50e18); // 50 $ORBS
 

--- a/test/MirakaiScrolls.t.sol
+++ b/test/MirakaiScrolls.t.sol
@@ -126,7 +126,7 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipCC0Mint();
 
         // set cc0TraitProbability to 100%
-        mirakaiScrolls.setCc0TraitsProbability(100);
+        mirakaiScrolls.setCc0TraitsProbability(10000);
 
         vm.startPrank(user1, user1);
 
@@ -410,7 +410,7 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipCC0Mint();
 
         // set cc0TraitProbability to 100%
-        mirakaiScrolls.setCc0TraitsProbability(100);
+        mirakaiScrolls.setCc0TraitsProbability(10000);
 
         vm.startPrank(user1, user1);
         mirakaiScrolls.cc0Mint(1, (signMessage(user1, 1, 1)));

--- a/test/MirakaiScrollsRenderer.t.sol
+++ b/test/MirakaiScrollsRenderer.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "ds-test/test.sol";
+import {console} from "forge-std/console.sol";
+import {MirakaiScrollsRenderer} from "../src/MirakaiScrollsRenderer.sol";
+import {MirakaiDnaParser} from "../src/MirakaiDnaParser.sol";
+import {TestVm} from "./TestVm.sol";
+
+contract MirakaiScrollsRendererTest is DSTest, TestVm {
+    MirakaiScrollsRenderer private mirakaiScrollsRenderer;
+    MirakaiDnaParser private mirakaiDnaParser;
+
+    function setUp() public {
+        mirakaiScrollsRenderer = new MirakaiScrollsRenderer();
+        mirakaiDnaParser = new MirakaiDnaParser();
+
+        mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
+
+        string[] memory inputs = new string[](2);
+        inputs[0] = "cat";
+        inputs[1] = "../initialize-scripts/slkscreeb.txt";
+        bytes memory fontData = vm.ffi(inputs);
+
+        mirakaiScrollsRenderer.saveFile(0, string(fontData));
+
+        setDnaParserTraitsAndWeights();
+    }
+
+    function testMirakaiScrollsRendererTokenURI() public view{
+        string memory dataURI = mirakaiScrollsRenderer.tokenURI(0, 0);
+
+        console.log(dataURI);
+    }
+
+    // --- utils ---
+
+    function setDnaParserTraitsAndWeights() internal {
+        MirakaiDnaParser.TraitWeights[]
+            memory tw = new MirakaiDnaParser.TraitWeights[](10);
+
+        uint256[] memory weights = new uint256[](6);
+        weights[0] = 1000;
+        weights[1] = 1000;
+        weights[2] = 1000;
+        weights[3] = 1000;
+        weights[4] = 1000;
+        weights[5] = 5000;
+
+        string[] memory clans = new string[](6);
+        clans[0] = "clan 1";
+        clans[1] = "clan 2";
+        clans[2] = "clan 3";
+        clans[3] = "clan 4";
+        clans[4] = "clan 5";
+        clans[5] = "clan 6";
+
+        string[] memory genus = new string[](6);
+        genus[0] = "genus 1";
+        genus[1] = "genus 2";
+        genus[2] = "genus 3";
+        genus[3] = "genus 4";
+        genus[4] = "genus 5";
+        genus[5] = "genus 6";
+
+        string[] memory heads = new string[](6);
+        heads[0] = "head 1";
+        heads[1] = "head 2";
+        heads[2] = "head 3";
+        heads[3] = "head 4";
+        heads[4] = "head 5";
+        heads[5] = "head 6";
+
+        string[] memory eyes = new string[](6);
+        eyes[0] = "eye 1";
+        eyes[1] = "eye 2";
+        eyes[2] = "eye 3";
+        eyes[3] = "eye 4";
+        eyes[4] = "eye 5";
+        eyes[5] = "eye 6";
+
+        string[] memory mouths = new string[](6);
+        mouths[0] = "mouth 1";
+        mouths[1] = "mouth 2";
+        mouths[2] = "mouth 3";
+        mouths[3] = "mouth 4";
+        mouths[4] = "mouth 5";
+        mouths[5] = "mouth 6";
+
+        string[] memory tops = new string[](6);
+        tops[0] = "top 1";
+        tops[1] = "top 2";
+        tops[2] = "top 3";
+        tops[3] = "top 4";
+        tops[4] = "top 5";
+        tops[5] = "top 6";
+
+        string[] memory bottoms = new string[](6);
+        bottoms[0] = "bottom 1";
+        bottoms[1] = "bottom 2";
+        bottoms[2] = "bottom 3";
+        bottoms[3] = "bottom 4";
+        bottoms[4] = "bottom 5";
+        bottoms[5] = "bottom 6";
+
+        string[] memory weapons = new string[](6);
+        weapons[0] = "weapons 1";
+        weapons[1] = "weapons 2";
+        weapons[2] = "weapons 3";
+        weapons[3] = "weapons 4";
+        weapons[4] = "weapons 5";
+        weapons[5] = "weapons 6";
+
+        string[] memory markings = new string[](6);
+        markings[0] = "markings 1";
+        markings[1] = "markings 2";
+        markings[2] = "markings 3";
+        markings[3] = "markings 4";
+        markings[4] = "markings 5";
+        markings[5] = "markings 6";
+
+        string[] memory cc0s = new string[](6);
+        cc0s[0] = "cc0 1";
+        cc0s[1] = "cc0 2";
+        cc0s[2] = "cc0 3";
+        cc0s[3] = "cc0 4";
+        cc0s[4] = "cc0 5";
+        cc0s[5] = "No cc0";
+
+        tw[0] = MirakaiDnaParser.TraitWeights(0, clans, weights);
+        tw[1] = MirakaiDnaParser.TraitWeights(1, genus, weights);
+        tw[2] = MirakaiDnaParser.TraitWeights(2, heads, weights);
+        tw[3] = MirakaiDnaParser.TraitWeights(3, eyes, weights);
+        tw[4] = MirakaiDnaParser.TraitWeights(4, mouths, weights);
+        tw[5] = MirakaiDnaParser.TraitWeights(5, tops, weights);
+        tw[6] = MirakaiDnaParser.TraitWeights(6, bottoms, weights);
+        tw[7] = MirakaiDnaParser.TraitWeights(7, weapons, weights);
+        tw[8] = MirakaiDnaParser.TraitWeights(8, markings, weights);
+        tw[9] = MirakaiDnaParser.TraitWeights(9, cc0s, weights);
+
+        mirakaiDnaParser.setTraitsAndWeights(tw);
+    }
+}


### PR DESCRIPTION
Besides some cleanup and gas optimizations the important changes are:

- `MirakaiDnaParser.sol:cc0Traits` function shifts the `dna` 14 bits more than needed. It should be shifted `14 * 9` not `14 * 10`.
- Custom errors introduced to use the `if(...) revert ERROR();` pattern rather than the `require` pattern.
- `cc0TraitsProbability` is considered to be in basis points. Some in the Foundry tests its value have been corrected to `100_00` to represent `100%`.
- `MirakaiScrolls.sol:cc0Mint` function's check on whether if it has rolled a `cc0` trait or not uses a formula that doesn't match with how the trait data is packed in `dna`; It uses left shift vs right shift to calculate `cc0` trait probability also the shift parameter is corrected to `14 * 9`:

Before:
```solidity
// MirakaiScrolls.sol:L206
if ((tokenDna << (14 * 10)) % 100 < cc0TraitsProbability) {
```

After:
```solidity
// MirakaiScrolls.sol:L213
if ((tokenDna >> (BIT_MASK_LENGTH * CC0_TRAIT_MULTIPLE)) % TOTAL_BPS < cc0TraitsProbability) {
```

- `test/MirakaiScrollsRenderer.t.sol` has been added to test that the `tokenURI` returns a `data URI` without any errors. Since it uses `ffi` to run this test use `forge test --ffi --match-test testMirakaiScrollsRendererTokenURI`