### PR TITLE
Optimizing Gas Usage

### DIFF
--- a/src/MirakaiDnaParser.sol
+++ b/src/MirakaiDnaParser.sol
@@ -154,7 +154,7 @@ contract MirakaiDnaParser is Ownable {
     {
         uint256 lowerBound;
         uint256 percentage;
-        uint8 i;
+        uint256 i;
         uint256 weightsLength = weights[index].length;
         for (; i < weightsLength; ) {
             percentage = weights[index][i];
@@ -182,7 +182,7 @@ contract MirakaiDnaParser is Ownable {
     {
         uint256[NUM_TRAITS] memory traitDnas = splitDna(dna);
 
-        uint8 i;
+        uint256 i;
         for (; i < NUM_TRAITS - 1; ) {
             traitIndexes[i] = getTraitIndex(traitDnas[i], i);
 
@@ -203,7 +203,7 @@ contract MirakaiDnaParser is Ownable {
         view
         returns (uint256[NUM_TRAITS] memory traitWeights)
     {
-        uint8 i;
+        uint256 i;
         for (; i < NUM_TRAITS; ) {
             traitWeights[i] = weights[i][traitIndexes[i]];
 
@@ -232,7 +232,7 @@ contract MirakaiDnaParser is Ownable {
         view
         returns (string[NUM_TRAITS] memory traitNames)
     {
-        uint8 i;
+        uint256 i;
         for (; i < NUM_TRAITS; ) {
             traitNames[i] = traits[i][traitIndexes[i]];
 

--- a/src/MirakaiHeroes.sol
+++ b/src/MirakaiHeroes.sol
@@ -28,14 +28,14 @@ contract MirakaiHeroes is Ownable, ERC721 {
 
     uint256 public constant MAX_SUPPLY = 10000;
 
+    // cost to summon
+    uint256 public summonCost;
+    uint256 public totalSupply;
+
     // upgradeable renderer
     address public heroesRenderer;
     address public orbsToken;
     address public mirakaiScrolls;
-
-    // cost to summon
-    uint256 public summonCost;
-    uint256 public totalSupply;
 
     // safety switch
     bool public summonActive;

--- a/src/MirakaiScrolls.sol
+++ b/src/MirakaiScrolls.sol
@@ -79,16 +79,23 @@ contract MirakaiScrolls is Ownable, ERC721 {
     uint256 public constant TEAM_RESERVE = 50;
     uint256 private constant CC0_TRAIT_MULTIPLE = 9;
 
-    address public scrollsRenderer;
-    address public orbsToken;
-
     uint256 public basePrice;
     uint256 public mintprice;
     uint256 public cc0TraitsProbability;
     uint256 public totalSupply;
+
     // cost in ORBS to reroll trait
     uint256 public rerollTraitCost;
     uint256 public numTeamMints;
+
+    // for pseudo-rng
+    uint256 private _seed;
+
+    address public scrollsRenderer;
+    address public orbsToken;
+    
+    // public key for sig verification
+    address private _signer;
 
     bool public mintIsActive;
     bool public cc0MintIsActive;
@@ -97,11 +104,6 @@ contract MirakaiScrolls is Ownable, ERC721 {
     // tokenId to dna
     mapping(uint256 => uint256) public dna;
 
-    // for pseudo-rng
-    uint256 private _seed;
-
-    // public key for sig verification
-    address private _signer;
 
     mapping(address => uint256) private allowListMinted;
     mapping(bytes => uint256) private cc0SignatureUsed;

--- a/src/MirakaiScrollsRenderer.sol
+++ b/src/MirakaiScrollsRenderer.sol
@@ -28,6 +28,7 @@ import "./interfaces/IMirakaiDnaParser.sol";
 contract MirakaiScrollsRenderer is Ownable {
 
     uint256 private constant SCROLL_WIDTH = 24;
+    uint256 public constant NUM_TRAITS = 10;
 
     address public mirakaDnaParser;
 
@@ -73,7 +74,6 @@ contract MirakaiScrollsRenderer is Ownable {
         string colorFour;
     }
 
-    uint256 public constant NUM_TRAITS = 10;
 
     constructor() {}
 
@@ -290,7 +290,7 @@ contract MirakaiScrollsRenderer is Ownable {
         ).getTraitWeights(traitIndexes);
 
         string memory svgItemsScroll;
-        uint8 i;
+        uint256 i;
         for (;i < NUM_TRAITS;) {
             // clear tag
             extraTag = "";


### PR DESCRIPTION
Ongoing PR for optimizations. 

One change was updating uint8 -> uint256. Going off a hunch that uint8 has some inefficiencies compared to 256 since the EVM uses 32bytes as a base which means there is more optcode to be doing w/ relation to uint8 vs 256. These were three tests that came up with gas savings as seen below (assuming `forge` gas usage is correct)
```
[PASS] testCC0Mint() (gas: 496421, new_gas: 494693, diff: 1728)
[PASS] testRerollTrait() (gas: 639978, new_gas: 638224, diff: 1754)
[PASS] testRerollTraitCost() (gas: 715911, new_gas: 714105, diff: 1806)
```

Second major change is tight packing. Using tight packing during the creation of, was able to squeeze out a few more gas gains. (Not 100% sure why there was actually an increase in gas usage from testPublicMintRevert, by 17. But will look into it). New changes + changes above result in these gas diffs
```
testBatchSummon() (
    gas: 825791, new_gas: 804794, diff: 20997, percentage_delta: 2.5426530441721935
)
testBurn() (
    gas: 459084, new_gas: 442259, diff: 16825, percentage_delta: 3.6649066401791393
)
testSummon() (
    gas: 766699, new_gas: 745702, diff: 20997, percentage_delta: 2.73862363195987
)
testAllowListMint() (
    gas: 291828, new_gas: 272746, diff: 19082, percentage_delta: 6.538783118823417
)
testAllowListMintRevertInvalidSig() (
    gas: 58766, new_gas: 39684, diff: 19082, percentage_delta: 32.47115679134193
)
testAllowListMintRevertNotActive() (
    gas: 45763, new_gas: 28681, diff: 17082, percentage_delta: 37.32709831086249
)
testAllowListMultipleMintRevert() (
    gas: 294538, new_gas: 275462, diff: 19076, percentage_delta: 6.476583666623662
)
testBasePrice() (
    gas: 338416, new_gas: 319340, diff: 19076, percentage_delta: 5.636849321545081
)
testBurn() (
    gas: 268620, new_gas: 253355, diff: 15265, percentage_delta: 5.6827488645670465
)
testCC0Mint() (
    gas: 496421, new_gas: 475251, diff: 21170, percentage_delta: 4.264525473338154
)
testCc0ListMultipleMintRevert() (
    gas: 297139, new_gas: 278063, diff: 19076, percentage_delta: 6.419891027431605
)
testCc0MintRevertInvalidSig() (
    gas: 58827, new_gas: 39745, diff: 19082, percentage_delta: 32.43748618831489
)
testCc0MintRevertNotActive() (
    gas: 45724, new_gas: 28642, diff: 17082, percentage_delta: 37.358936226051966
)
testMintPrice() (
    gas: 611006, new_gas: 591998, diff: 19008, percentage_delta: 3.1109350808339036
)
testOrbsDripping() (
    gas: 606101, new_gas: 589052, diff: 17049, percentage_delta: 2.8128975203802664
)
testPublicMint() (
    gas: 463926, new_gas: 446877, diff: 17049, percentage_delta: 3.6749395377711105
)
testPublicMintRevert() (
    gas: 17482, new_gas: 17499, diff: -17, percentage_delta: -0.09724287838920032
)
testRerollTrait() (
    gas: 639978, new_gas: 620810, diff: 19168, percentage_delta: 2.995102956664135
)
testRerollTraitCost() (
    gas: 715911, new_gas: 696681, diff: 19230, percentage_delta: 2.6860880751937044
)
testRerollTraitRevert() (
    gas: 463423, new_gas: 446374, diff: 17049, percentage_delta: 3.678928322504494
)
testTeamMint() (
    gas: 2788959, new_gas: 2788959, diff: 0, percentage_delta: 0.0
)
```
