### PR TITLE
Gas optimizations

### DIFF
--- a/src/ERC721.sol
+++ b/src/ERC721.sol
@@ -359,8 +359,10 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         require(!_exists(tokenId), "ERC721: token already minted");
 
         _beforeTokenTransfer(address(0), to, tokenId);
-
-        _users[to].balance += 1;
+        // Overflow is unrealistic
+        unchecked {
+            _users[to].balance += 1;
+        }
         _owners[tokenId] = to;
 
         emit Transfer(address(0), to, tokenId);
@@ -385,8 +387,10 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
 
         // Clear approvals
         _approve(address(0), tokenId);
-
-        _users[owner].balance -= 1;
+        // Overflow is impossible due to the ownership of `tokenId`
+        unchecked {
+            _users[owner].balance -= 1;
+        }
         delete _owners[tokenId];
 
         emit Transfer(owner, address(0), tokenId);
@@ -416,9 +420,12 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
 
         // Clear approvals from the previous owner
         _approve(address(0), tokenId);
-
-        _users[from].balance -= 1;
-        _users[to].balance += 1;
+        // Underflow is impossible due to the ownership of `tokenId`
+        // Overflow is unrealistic
+        unchecked {
+            _users[from].balance -= 1;
+            _users[to].balance += 1;
+        }
         _owners[tokenId] = to;
 
         emit Transfer(from, to, tokenId);

--- a/src/ERC721.sol
+++ b/src/ERC721.sol
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC721/ERC721.sol)
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+/**
+ * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard, including
+ * the Metadata extension, but not including the Enumerable extension, which is available separately as
+ * {ERC721Enumerable}.
+ */
+contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
+    using Address for address;
+    using Strings for uint256;
+
+    struct User {
+        uint248 balance;
+        uint8 mintedAllowList;
+    }
+
+    // Token name
+    string private _name;
+
+    // Token symbol
+    string private _symbol;
+
+    // Mapping from token ID to owner address
+    mapping(uint256 => address) private _owners;
+
+    // Mapping owner address to token count
+    mapping(address => User) private _users;
+
+    // Mapping from token ID to approved address
+    mapping(uint256 => address) private _tokenApprovals;
+
+    // Mapping from owner to operator approvals
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override (ERC165, IERC165)
+        returns (bool)
+    {
+        return
+            interfaceId == type(IERC721).interfaceId ||
+            interfaceId == type(IERC721Metadata).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function balanceOf(address owner)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        require(owner != address(0), "ERC721: balance query for the zero address");
+        return _users[owner].balance;
+    }
+
+    /**
+     * @dev See {IERC721-ownerOf}.
+     */
+    function ownerOf(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (address)
+    {
+        address owner = _owners[tokenId];
+        require(owner != address(0), "ERC721: owner query for nonexistent token");
+        return owner;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-name}.
+     */
+    function name() public view virtual override returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-symbol}.
+     */
+    function symbol() public view virtual override returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-tokenURI}.
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
+
+        string memory baseURI = _baseURI();
+        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+    }
+
+    /**
+     * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
+     * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
+     * by default, can be overriden in child contracts.
+     */
+    function _baseURI() internal view virtual returns (string memory) {
+        return "";
+    }
+
+    /**
+     * @dev Can be used to fetch the allow list mint status of an address.
+     * @return uint256 Whether the address has minted using the whitelist or not.
+     */
+    function _getMintedAllowList(address owner)
+        internal
+        view
+        returns (uint256)
+    {
+        return _users[owner].mintedAllowList;
+    }
+
+    /**
+     * @dev Can be used to set the allow list mint status of an address.
+     */
+    function _setMintedAllowList(address owner, uint256 amount) internal {
+        // Not required due to the functions that use `_setMintedAllowList` having a hard coded value of 1.
+        // require(amount <= type(uint8).max);
+        _users[owner].mintedAllowList = uint8(amount);
+    }
+
+    /**
+     * @dev See {IERC721-approve}.
+     */
+    function approve(address to, uint256 tokenId) public virtual override {
+        address owner = ERC721.ownerOf(tokenId);
+        require(to != owner, "ERC721: approval to current owner");
+
+        require(
+            _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
+            "ERC721: approve caller is not owner nor approved for all"
+        );
+
+        _approve(to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC721-getApproved}.
+     */
+    function getApproved(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (address)
+    {
+        require(_exists(tokenId), "ERC721: approved query for nonexistent token");
+
+        return _tokenApprovals[tokenId];
+    }
+
+    /**
+     * @dev See {IERC721-setApprovalForAll}.
+     */
+    function setApprovalForAll(address operator, bool approved)
+        public
+        virtual
+        override
+    {
+        _setApprovalForAll(_msgSender(), operator, approved);
+    }
+
+    /**
+     * @dev See {IERC721-isApprovedForAll}.
+     */
+    function isApprovedForAll(address owner, address operator)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev See {IERC721-transferFrom}.
+     */
+    function transferFrom(address from, address to, uint256 tokenId)
+        public
+        virtual
+        override
+    {
+        //solhint-disable-next-line max-line-length
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
+
+        _transfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId)
+        public
+        virtual
+        override
+    {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    )
+        public
+        virtual
+        override
+    {
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
+        _safeTransfer(from, to, tokenId, _data);
+    }
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * `_data` is additional data, it has no specified format and it is sent in call to `to`.
+     *
+     * This internal function is equivalent to {safeTransferFrom}, and can be used to e.g.
+     * implement alternative mechanisms to perform token transfer, such as signature-based.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeTransfer(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    )
+        internal
+        virtual
+    {
+        _transfer(from, to, tokenId);
+        require(_checkOnERC721Received(from, to, tokenId, _data), "ERC721: transfer to non ERC721Receiver implementer");
+    }
+
+    /**
+     * @dev Returns whether `tokenId` exists.
+     *
+     * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
+     *
+     * Tokens start existing when they are minted (`_mint`),
+     * and stop existing when they are burned (`_burn`).
+     */
+    function _exists(uint256 tokenId) internal view virtual returns (bool) {
+        return _owners[tokenId] != address(0);
+    }
+
+    /**
+     * @dev Returns whether `spender` is allowed to manage `tokenId`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenId)
+        internal
+        view
+        virtual
+        returns (bool)
+    {
+        require(_exists(tokenId), "ERC721: operator query for nonexistent token");
+        address owner = ERC721.ownerOf(tokenId);
+        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender));
+    }
+
+    /**
+     * @dev Safely mints `tokenId` and transfers it to `to`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must not exist.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeMint(address to, uint256 tokenId) internal virtual {
+        _safeMint(to, tokenId, "");
+    }
+
+    /**
+     * @dev Same as {xref-ERC721-_safeMint-address-uint256-}[`_safeMint`], with an additional `data` parameter which is
+     * forwarded in {IERC721Receiver-onERC721Received} to contract recipients.
+     */
+    function _safeMint(address to, uint256 tokenId, bytes memory _data)
+        internal
+        virtual
+    {
+        _mint(to, tokenId);
+        require(
+            _checkOnERC721Received(address(0), to, tokenId, _data),
+            "ERC721: transfer to non ERC721Receiver implementer"
+        );
+    }
+
+    /**
+     * @dev Mints `tokenId` and transfers it to `to`.
+     *
+     * WARNING: Usage of this method is discouraged, use {_safeMint} whenever possible
+     *
+     * Requirements:
+     *
+     * - `tokenId` must not exist.
+     * - `to` cannot be the zero address.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _mint(address to, uint256 tokenId) internal virtual {
+        require(to != address(0), "ERC721: mint to the zero address");
+        require(!_exists(tokenId), "ERC721: token already minted");
+
+        _beforeTokenTransfer(address(0), to, tokenId);
+
+        _users[to].balance += 1;
+        _owners[tokenId] = to;
+
+        emit Transfer(address(0), to, tokenId);
+
+        _afterTokenTransfer(address(0), to, tokenId);
+    }
+
+    /**
+     * @dev Destroys `tokenId`.
+     * The approval is cleared when the token is burned.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _burn(uint256 tokenId) internal virtual {
+        address owner = ERC721.ownerOf(tokenId);
+
+        _beforeTokenTransfer(owner, address(0), tokenId);
+
+        // Clear approvals
+        _approve(address(0), tokenId);
+
+        _users[owner].balance -= 1;
+        delete _owners[tokenId];
+
+        emit Transfer(owner, address(0), tokenId);
+
+        _afterTokenTransfer(owner, address(0), tokenId);
+    }
+
+    /**
+     * @dev Transfers `tokenId` from `from` to `to`.
+     *  As opposed to {transferFrom}, this imposes no restrictions on msg.sender.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _transfer(address from, address to, uint256 tokenId)
+        internal
+        virtual
+    {
+        require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
+        require(to != address(0), "ERC721: transfer to the zero address");
+
+        _beforeTokenTransfer(from, to, tokenId);
+
+        // Clear approvals from the previous owner
+        _approve(address(0), tokenId);
+
+        _users[from].balance -= 1;
+        _users[to].balance += 1;
+        _owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+
+        _afterTokenTransfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Approve `to` to operate on `tokenId`
+     *
+     * Emits a {Approval} event.
+     */
+    function _approve(address to, uint256 tokenId) internal virtual {
+        _tokenApprovals[tokenId] = to;
+        emit Approval(ERC721.ownerOf(tokenId), to, tokenId);
+    }
+
+    /**
+     * @dev Approve `operator` to operate on all of `owner` tokens
+     *
+     * Emits a {ApprovalForAll} event.
+     */
+    function _setApprovalForAll(address owner, address operator, bool approved)
+        internal
+        virtual
+    {
+        require(owner != operator, "ERC721: approve to caller");
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
+     * The call is not executed if the target address is not a contract.
+     *
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the tokens
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param _data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected magic value
+     */
+    function _checkOnERC721Received(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    )
+        private
+        returns (bool)
+    {
+        if (to.isContract()) {
+            try IERC721Receiver(to).onERC721Received(_msgSender(), from, tokenId, _data) returns (bytes4 retval) {
+                return retval == IERC721Receiver.onERC721Received.selector;
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert("ERC721: transfer to non ERC721Receiver implementer");
+                } else {
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * @dev Hook that is called before any token transfer. This includes minting
+     * and burning.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be
+     * transferred to `to`.
+     * - When `from` is zero, `tokenId` will be minted for `to`.
+     * - When `to` is zero, ``from``'s `tokenId` will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId)
+        internal
+        virtual
+    {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(address from, address to, uint256 tokenId)
+        internal
+        virtual
+    {}
+}

--- a/src/MirakaiScrolls.sol
+++ b/src/MirakaiScrolls.sol
@@ -195,10 +195,10 @@ contract MirakaiScrolls is Ownable, ERC721 {
         // can mint multiple different cc0s if wallet contains them,
         // so we have to nullify signatures rather than msg.sender
         if (cc0SignatureUsed[abi.encodePacked(v, r, s)] > 0)
-        revert WalletAlreadyMinted();
+            revert WalletAlreadyMinted();
 
         if (!verify(getMessageHash(msg.sender, 1, cc0Index), v, r, s))
-        revert InvalidSignature();
+            revert InvalidSignature();
 
         unchecked {
             uint256 tokenDna = uint256(

--- a/src/MirakaiScrolls.sol
+++ b/src/MirakaiScrolls.sol
@@ -71,8 +71,8 @@ contract MirakaiScrolls is Ownable, ERC721 {
     error WalletAlreadyMinted();
     error ERC721Burnable_CallerIsNotOwnerNorApproved();
 
-	// this is 14 bits of 1s - the size of a trait 'slot' in the dna	
-    uint256 public constant BIT_MASK_LENGTH = 14;	
+	// this is 14 bits of 1s - the size of a trait 'slot' in the dna
+    uint256 public constant BIT_MASK_LENGTH = 14;
     uint256 public constant BIT_MASK = 2**BIT_MASK_LENGTH - 1;
     uint256 public constant MAX_SUPPLY = 10000;
     uint256 private constant TOTAL_BPS = 10000;

--- a/test/MirakaiHeroes.t.sol
+++ b/test/MirakaiHeroes.t.sol
@@ -78,7 +78,8 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         orbs.approve(address(mirakaiHeroes), type(uint256).max);
 
         // mint 6 tokens total
-        mirakaiScrolls.cc0Mint(1, (signMessage(user1, 1, 1)));
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
         mirakaiScrolls.publicMint(5);
 
         // dna
@@ -130,7 +131,8 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         orbs.approve(address(mirakaiHeroes), type(uint256).max);
 
         // mint 6 tokens total
-        mirakaiScrolls.cc0Mint(1, (signMessage(user1, 1, 1)));
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
         mirakaiScrolls.publicMint(5);
 
         // dna
@@ -188,7 +190,8 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         vm.startPrank(user1, user1);
         orbs.approve(address(mirakaiHeroes), type(uint256).max);
 
-        mirakaiScrolls.cc0Mint(1, (signMessage(user1, 1, 1)));
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
 
         assertEq(orbs.balanceOf(user1), 50e18);
 
@@ -212,7 +215,7 @@ contract MirakaiHeroesTest is DSTest, TestVm {
         address minter,
         uint256 quantity,
         uint256 cc0Index
-    ) internal returns (bytes memory) {
+    ) internal returns (uint8, bytes32, bytes32) {
         bytes32 messageHash = mirakaiScrolls.getMessageHash(
             minter,
             quantity,
@@ -226,7 +229,7 @@ contract MirakaiHeroesTest is DSTest, TestVm {
             signerPk,
             ethSignedMessageHash
         );
-        return abi.encodePacked(r, s, v);
+        return (v, r, s);
     }
 
     function setDnaParserTraitsAndWeights() internal {

--- a/test/MirakaiScrolls.t.sol
+++ b/test/MirakaiScrolls.t.sol
@@ -79,7 +79,8 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipAllowListMint();
 
         vm.startPrank(user1, user1);
-        mirakaiScrolls.allowListMint(signMessage(user1, 1, 0));
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 0);
+        mirakaiScrolls.allowListMint(v, r, s);
 
         assertEq(mirakaiScrolls.balanceOf(user1), 1);
         assertEq(mirakaiScrolls.totalSupply(), 1);
@@ -90,9 +91,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipAllowListMint();
 
         vm.startPrank(user1, user1);
-        bytes memory signature = signMessage(user2, 1, 0);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user2, 1, 0);
         vm.expectRevert(MirakaiScrolls.InvalidSignature.selector);
-        mirakaiScrolls.allowListMint(signature);
+        mirakaiScrolls.allowListMint(v, r, s);
     }
 
     // wallet cannot mint multiple times
@@ -100,14 +101,14 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipAllowListMint();
 
         vm.startPrank(user1, user1);
-        bytes memory signature = signMessage(user1, 1, 0);
-        mirakaiScrolls.allowListMint(signature);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 0);
+        mirakaiScrolls.allowListMint(v, r, s);
 
         assertEq(mirakaiScrolls.balanceOf(user1), 1);
         assertEq(mirakaiScrolls.totalSupply(), 1);
 
         vm.expectRevert(MirakaiScrolls.WalletAlreadyMinted.selector);
-        mirakaiScrolls.allowListMint(signature);
+        mirakaiScrolls.allowListMint(v, r, s);
     }
 
     // should revert if mint is not active
@@ -116,9 +117,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipCC0Mint();
 
         vm.startPrank(user1, user1);
-        bytes memory signature = signMessage(user1, 1, 0);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 0);
         vm.expectRevert(MirakaiScrolls.MintNotActive.selector);
-        mirakaiScrolls.allowListMint(signature);
+        mirakaiScrolls.allowListMint(v, r, s);
     }
 
     // should mint token with cc0 trait
@@ -131,7 +132,8 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         vm.startPrank(user1, user1);
 
         // mint token with cc0Trait 1
-        mirakaiScrolls.cc0Mint(1, (signMessage(user1, 1, 1)));
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
 
         assertEq(mirakaiScrolls.balanceOf(user1), 1);
         // check that cc0Index was properly set for token
@@ -170,9 +172,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipCC0Mint();
 
         vm.startPrank(user1, user1);
-        bytes memory signature = signMessage(user2, 1, 0);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user2, 1, 0);
         vm.expectRevert(MirakaiScrolls.InvalidSignature.selector);
-        mirakaiScrolls.cc0Mint(1, signature);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
     }
 
     // wallet cannot mint multiple times
@@ -180,14 +182,14 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipCC0Mint();
 
         vm.startPrank(user1, user1);
-        bytes memory signature = signMessage(user1, 1, 1);
-        mirakaiScrolls.cc0Mint(1, signature);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
 
         assertEq(mirakaiScrolls.balanceOf(user1), 1);
         assertEq(mirakaiScrolls.totalSupply(), 1);
 
         vm.expectRevert(MirakaiScrolls.WalletAlreadyMinted.selector);
-        mirakaiScrolls.cc0Mint(1, signature);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
     }
 
     // should revert if mint is not active
@@ -196,9 +198,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipAllowListMint();
 
         vm.startPrank(user1, user1);
-        bytes memory signature = signMessage(user1, 1, 0);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 0);
         vm.expectRevert(MirakaiScrolls.MintNotActive.selector);
-        mirakaiScrolls.cc0Mint(1, signature);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
     }
 
     // set base price for cc0 mint
@@ -209,9 +211,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipCC0Mint();
 
         vm.startPrank(user1, user1);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
         mirakaiScrolls.cc0Mint{value: 0.05 ether}(
-            1,
-            (signMessage(user1, 1, 1))
+            1, v, r, s
         );
 
         assertEq(mirakaiScrolls.balanceOf(user1), 1);
@@ -223,9 +225,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         // revert if not enough ether sent
         vm.deal(user2, 10 ether);
         vm.startPrank(user2, user2);
-        bytes memory signature = (signMessage(user2, 1, 1));
+        (uint8 v2, bytes32 r2, bytes32 s2) = signMessage(user2, 1, 1);
         vm.expectRevert(MirakaiScrolls.IncorrectEtherValue.selector);
-        mirakaiScrolls.cc0Mint{value: 0.03 ether}(1, signature);
+        mirakaiScrolls.cc0Mint{value: 0.03 ether}(1, v2, r2, s2);
     }
 
     // set mint price for AL and public mint
@@ -238,8 +240,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.flipMint();
 
         vm.startPrank(user1, user1);
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 0);
         mirakaiScrolls.allowListMint{value: 0.1 ether}(
-            (signMessage(user1, 1, 0))
+            v, r, s
         );
 
         mirakaiScrolls.publicMint{value: 0.5 ether}(5);
@@ -251,9 +254,9 @@ contract MirakaiScrollsTest is DSTest, TestVm {
 
         // revert if not enough ether sent
         vm.startPrank(user2, user2);
-        bytes memory signature = (signMessage(user2, 1, 0));
+        (uint8 v2, bytes32 r2, bytes32 s2) = signMessage(user2, 1, 0);
         vm.expectRevert(MirakaiScrolls.IncorrectEtherValue.selector);
-        mirakaiScrolls.allowListMint{value: 0.03 ether}(signature);
+        mirakaiScrolls.allowListMint{value: 0.03 ether}(v2, r2, s2);
 
         vm.expectRevert(MirakaiScrolls.IncorrectEtherValue.selector);
         mirakaiScrolls.publicMint{value: 0.03 ether}(5);
@@ -413,7 +416,8 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         mirakaiScrolls.setCc0TraitsProbability(10000);
 
         vm.startPrank(user1, user1);
-        mirakaiScrolls.cc0Mint(1, (signMessage(user1, 1, 1)));
+        (uint8 v, bytes32 r, bytes32 s) = signMessage(user1, 1, 1);
+        mirakaiScrolls.cc0Mint(1, v, r, s);
 
         assertEq(mirakaiScrolls.balanceOf(user1), 1);
         // check that cc0Index was properly set for token
@@ -435,7 +439,7 @@ contract MirakaiScrollsTest is DSTest, TestVm {
         address minter,
         uint256 quantity,
         uint256 cc0Index
-    ) internal returns (bytes memory) {
+    ) internal returns (uint8, bytes32, bytes32) {
         bytes32 messageHash = mirakaiScrolls.getMessageHash(
             minter,
             quantity,
@@ -449,7 +453,7 @@ contract MirakaiScrollsTest is DSTest, TestVm {
             signerPk,
             ethSignedMessageHash
         );
-        return abi.encodePacked(r, s, v);
+        return (v, r, s);
     }
 
     function setDnaParserTraitsAndWeights() internal {


### PR DESCRIPTION
This PR includes 2 different gas optimizations:

- Changing the signatures from bytes memory to its 3 parts (v, r, s). This already gets done internally in ECDSA.sol when passing in bytes as an argument, and thus saves some gas in array manipulation and calldata size costs.
- Added ERC721.sol to be able to edit it and add a whitelist mint counter inside the balance mapping, this saves some gas when it comes to minting with allowlist. There are also some `unchecked` blocks added in places where overflow/underflow is impossible/unrealistic for some extra gas savings.

Note: The tests for both MirakaiScrolls and MirakaiHeroes had to be edited to accommodate the signature change.