### PR TITLE
Gigadrip20 optimizations

### DIFF
--- a/lib/DRIP20/src/GIGADRIP20.sol
+++ b/lib/DRIP20/src/GIGADRIP20.sol
@@ -59,8 +59,8 @@ abstract contract GIGADRIP20 {
 
     // these are all for calculating totalSupply()
     uint256 private _currAccrued;
-    uint256 private _currEmissionBlockNum;
-    uint256 private _currEmissionMultiple;
+    uint128 private _currEmissionBlockNum;
+    uint128 private _currEmissionMultiple;
 
     constructor(
         string memory _name,
@@ -175,12 +175,12 @@ abstract contract GIGADRIP20 {
         Accruer storage accruer = _accruers[addr];
 
         _currAccrued = totalSupply();
-        _currEmissionBlockNum = block.number;
+        _currEmissionBlockNum = uint128(block.number);
         accruer.accrualStartBlock = uint64(block.number);
 
         // should not overflow unless you have >2**256-1 items...
         unchecked {
-            _currEmissionMultiple += multiplier;
+            _currEmissionMultiple += uint128(multiplier);
             accruer.multiplier += uint64(multiplier);
         }
 
@@ -211,10 +211,10 @@ abstract contract GIGADRIP20 {
 
         accruer.balance = uint128(balanceOf(addr));
         _currAccrued = totalSupply();
-        _currEmissionBlockNum = block.number;
+        _currEmissionBlockNum = uint128(block.number);
 
         // will revert if underflow occurs
-        _currEmissionMultiple -= multiplier;
+        _currEmissionMultiple -= uint128(multiplier);
         accruer.multiplier -= uint64(multiplier);
 
         if (accruer.multiplier == 0) {
@@ -244,7 +244,7 @@ abstract contract GIGADRIP20 {
 
         // have to update supply before burning
         _currAccrued = totalSupply();
-        _currEmissionBlockNum = block.number;
+        _currEmissionBlockNum = uint128(block.number);
 
         accruer.balance = uint128(balanceOf(from) - amount);
 

--- a/lib/DRIP20/src/GIGADRIP20.sol
+++ b/lib/DRIP20/src/GIGADRIP20.sol
@@ -114,7 +114,7 @@ abstract contract GIGADRIP20 {
         return true;
     }
 
-    function balanceOf(address addr) public view returns (uint128) {
+    function balanceOf(address addr) public view returns (uint256) {
         Accruer memory accruer = _accruers[addr];
 
         if (accruer.accrualStartBlock == 0) {
@@ -187,7 +187,7 @@ abstract contract GIGADRIP20 {
         // need to update the balance to start "fresh"
         // from the updated block and updated multiplier if the addr was already accruing
         if (accruer.accrualStartBlock != 0) {
-            accruer.balance = balanceOf(addr);
+            accruer.balance = uint128(balanceOf(addr));
         } else {
             // emit Transfer event when new address starts dripping
             emit Transfer(address(0), addr, 0);
@@ -209,7 +209,7 @@ abstract contract GIGADRIP20 {
         // should I check for 0 multiplier too
         require(accruer.accrualStartBlock != 0, "user not accruing");
 
-        accruer.balance = balanceOf(addr);
+        accruer.balance = uint128(balanceOf(addr));
         _currAccrued = totalSupply();
         _currEmissionBlockNum = block.number;
 

--- a/lib/DRIP20/src/GIGADRIP20.sol
+++ b/lib/DRIP20/src/GIGADRIP20.sol
@@ -47,7 +47,7 @@ abstract contract GIGADRIP20 {
         uint128 balance;
         // 0 ~ (2^64) - 1 is more than enough for the user's multiplier as the balance would overflow anyway (even using a 256-bit unsigned value).
         uint64 multiplier;
-        // 0 ~ (2^64) - 1 is more than enough for block numbers
+        // 0 ~ (2^64) - 1 is more than enough for block numbers.
         uint64 accrualStartBlock;
     }
 


### PR DESCRIPTION
Optimizes the `GIGADRIP20` contract:
- By changing the `Accurer` struct size to a single slot.
- By changing the size of `_currEmissionBlockNum` and `_currEmissionMultiple` to uint128s which allow them to be packed inside the same slot as well.
These changes help *a lot* with minting costs in the `MirakaiScrolls` contract.