### PR TITLE
Avoiding initial set transactions by updating in constructors

### DIFF
--- a/hh-integration-test/integration-test.js
+++ b/hh-integration-test/integration-test.js
@@ -42,11 +42,11 @@ describe("Mirakai Full integration tests", function () {
     [owner, addr1, addr2, ...addrs] = await ethers.getSigners();
 
     mirakaiScrolls = await mirakaiScrollsFactory.deploy();
-    mirakaiScrollsRenderer = await mirakaiScrollsRendererFactory.deploy();
+    mirakaiDnaParser = await mirakaiDnaParserFactory.deploy();
+    mirakaiScrollsRenderer = await mirakaiScrollsRendererFactory.deploy(mirakaiDnaParser.address);
     mirakaiHeroes = await mirakaiHeroesFactory.deploy();
     mirakaiHeroesRenderer = await mirakaiHeroesRendererFactory.deploy("mock.com/");
-    mirakaiDnaParser = await mirakaiDnaParserFactory.deploy();
-    orbs = await orbsFactory.deploy("mock", "mock", 18, 10);
+    orbs = await orbsFactory.deploy("mock", "mock", 18, 10, mirakaiScrolls.address);
     
     await mirakaiScrolls.initialize(
         mirakaiScrollsRenderer.address,
@@ -65,8 +65,8 @@ describe("Mirakai Full integration tests", function () {
         0
     );
 
-    await mirakaiScrollsRenderer.setmirakaiDnaParser(mirakaiDnaParser.address);
-    await orbs.setmirakaiScrolls(mirakaiScrolls.address);
+    //await mirakaiScrollsRenderer.setmirakaiDnaParser(mirakaiDnaParser.address);
+    //await orbs.setmirakaiScrolls(mirakaiScrolls.address);
 
     const files = [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mirakai",
+  "name": "Mirakai",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/script/deploy.sol
+++ b/script/deploy.sol
@@ -34,16 +34,15 @@ contract Deploy is TestVm {
 
         MirakaiDnaParser mirakaiDnaParser = new MirakaiDnaParser();
 
-        MirakaiScrollsRenderer mirakaiScrollsRenderer = new MirakaiScrollsRenderer();
-        mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
-
-        OrbsToken orbsToken = new OrbsToken("test", "test", 18, 2500);
+        MirakaiScrollsRenderer mirakaiScrollsRenderer = new MirakaiScrollsRenderer(address(mirakaiDnaParser));
+        //mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
 
         MirakaiHeroesRenderer mirakaiHeroesRenderer = new MirakaiHeroesRenderer(
             "mock.com/"
         );
 
         MirakaiScrolls mirakaiScrolls = new MirakaiScrolls();
+        OrbsToken orbsToken = new OrbsToken("test", "test", 18, 2500, address(mirakaiScrolls));
         mirakaiScrolls.initialize(
             address(mirakaiScrollsRenderer),
             address(orbsToken),
@@ -53,8 +52,8 @@ contract Deploy is TestVm {
             0,
             928374
         );
-
-        orbsToken.setmirakaiScrolls(address(mirakaiScrolls));
+    
+        //orbsToken.setmirakaiScrolls(address(mirakaiScrolls));
 
         MirakaiHeroes mirakaiHeroes = new MirakaiHeroes();
         mirakaiHeroes.initialize(

--- a/src/MirakaiScrollsRenderer.sol
+++ b/src/MirakaiScrollsRenderer.sol
@@ -73,7 +73,9 @@ contract MirakaiScrollsRenderer is Ownable {
         string colorFour;
     }
 
-    constructor() {}
+    constructor(address _mirakaDnaParser) {
+        mirakaDnaParser = _mirakaDnaParser;
+    }
 
     /**
      * @dev essentially creating jsonify by constructing the metadata json + SVG image. Pain.

--- a/src/OrbsToken/OrbsToken.sol
+++ b/src/OrbsToken/OrbsToken.sol
@@ -24,8 +24,11 @@ contract OrbsToken is Ownable, GIGADRIP20 {
         string memory _name,
         string memory _symbol,
         uint8 _decimals,
-        uint256 _emissionRatePerBlock
-    ) GIGADRIP20(_name, _symbol, _decimals, _emissionRatePerBlock) {}
+        uint256 _emissionRatePerBlock,
+        address _mirakaiScrolls
+    ) GIGADRIP20(_name, _symbol, _decimals, _emissionRatePerBlock) {
+        mirakaiScrolls = _mirakaiScrolls;
+    }
 
     /*==============================================================
     ==                    Dripping Functions                      ==

--- a/test/MirakaiHeroes.t.sol
+++ b/test/MirakaiHeroes.t.sol
@@ -31,10 +31,10 @@ contract MirakaiHeroesTest is DSTest, TestVm {
     function setUp() public {
         mirakaiHeroes = new MirakaiHeroes();
         mirakaiHeroesRenderer = new MirakaiHeroesRenderer("mock.com/");
-        mirakaiScrollsRenderer = new MirakaiScrollsRenderer();
         mirakaiDnaParser = new MirakaiDnaParser();
+        mirakaiScrollsRenderer = new MirakaiScrollsRenderer(address(mirakaiDnaParser));
         mirakaiScrolls = new MirakaiScrolls();
-        orbs = new OrbsToken("mock", "mock", 18, 10);
+        orbs = new OrbsToken("mock", "mock", 18, 10, address(mirakaiScrolls));
 
         mirakaiHeroes.initialize(
             address(mirakaiHeroesRenderer),
@@ -53,8 +53,8 @@ contract MirakaiHeroesTest is DSTest, TestVm {
             0 // seed
         );
 
-        mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
-        orbs.setmirakaiScrolls(address(mirakaiScrolls));
+        //mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
+        //orbs.setmirakaiScrolls(address(mirakaiScrolls));
         setDnaParserTraitsAndWeights();
     }
 

--- a/test/MirakaiScrolls.t.sol
+++ b/test/MirakaiScrolls.t.sol
@@ -26,10 +26,10 @@ contract MirakaiScrollsTest is DSTest, TestVm {
     address user3 = 0xdb3f55B9559566c57987e523Be1aFb09Dd5df59c;
 
     function setUp() public {
-        mirakaiScrollsRenderer = new MirakaiScrollsRenderer();
         mirakaiDnaParser = new MirakaiDnaParser();
+        mirakaiScrollsRenderer = new MirakaiScrollsRenderer(address(mirakaiDnaParser));
         mirakaiScrolls = new MirakaiScrolls();
-        orbs = new OrbsToken("mock", "mock", 18, 10);
+        orbs = new OrbsToken("mock", "mock", 18, 10, address(mirakaiScrolls));
 
         mirakaiScrolls.initialize(
             address(mirakaiScrollsRenderer),
@@ -40,8 +40,8 @@ contract MirakaiScrollsTest is DSTest, TestVm {
             0, // rerollTraitCost
             0 // seed
         );
-        mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
-        orbs.setmirakaiScrolls(address(mirakaiScrolls));
+        //mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
+        //orbs.setmirakaiScrolls(address(mirakaiScrolls));
         setDnaParserTraitsAndWeights();
     }
 

--- a/test/MirakaiScrollsRenderer.t.sol
+++ b/test/MirakaiScrollsRenderer.t.sol
@@ -12,10 +12,9 @@ contract MirakaiScrollsRendererTest is DSTest, TestVm {
     MirakaiDnaParser private mirakaiDnaParser;
 
     function setUp() public {
-        mirakaiScrollsRenderer = new MirakaiScrollsRenderer();
         mirakaiDnaParser = new MirakaiDnaParser();
-
-        mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
+        mirakaiScrollsRenderer = new MirakaiScrollsRenderer(address(mirakaiDnaParser));
+        //mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
 
         string[] memory inputs = new string[](2);
         inputs[0] = "cat";


### PR DESCRIPTION
During deployment, following 2 transactions are found that can be avoided using constructors :- 
1.     mirakaiScrollsRenderer.setmirakaiDnaParser(address(mirakaiDnaParser));
2.     orbs.setmirakaiScrolls(address(mirakaiScrolls));